### PR TITLE
[FEAT] 사용자 로그인 성공 시 토큰 및 userId 추가 기능 구현

### DIFF
--- a/src/main/java/com/homefit/backend/login/controller/UserAuthController.java
+++ b/src/main/java/com/homefit/backend/login/controller/UserAuthController.java
@@ -1,6 +1,7 @@
 package com.homefit.backend.login.controller;
 
-import com.homefit.backend.login.dto.LoginDto;
+import com.homefit.backend.login.dto.LoginRequestDto;
+import com.homefit.backend.login.dto.LoginResponseDto;
 import com.homefit.backend.login.dto.PasswordChangeDto;
 import com.homefit.backend.login.dto.UserDto;
 import com.homefit.backend.login.service.AuthenticationService;
@@ -57,15 +58,15 @@ public class UserAuthController {
             @ApiResponse(responseCode = "401", description = "인증 실패")
     })
     @PostMapping("/login")
-    public ResponseEntity<String> login(@RequestBody LoginDto loginDto) {
-        log.info("Attempting login for user: {}", loginDto.getUserName());
+    public ResponseEntity<LoginResponseDto> login(@RequestBody LoginRequestDto loginRequestDto) {
+        log.info("Attempting login for user: {}", loginRequestDto.getUserName());
         try {
-            String token = authenticationService.login(loginDto);
-            log.info("Login successful for user: {}", loginDto.getUserName());
-            return ResponseEntity.ok(token);
+            LoginResponseDto response = authenticationService.login(loginRequestDto);
+            log.info("Login successful for user: {}", loginRequestDto.getUserName());
+            return ResponseEntity.ok(response);
         } catch (Exception e) {
-            log.error("Login failed for user: {}", loginDto.getUserName(), e);
-            return ResponseEntity.badRequest().body("아이디 혹은 비밀번호가 일치하지 않아요...");
+            log.error("Login failed for user: {}", loginRequestDto.getUserName(), e);
+            return ResponseEntity.badRequest().body(null);
         }
     }
 

--- a/src/main/java/com/homefit/backend/login/dto/LoginRequestDto.java
+++ b/src/main/java/com/homefit/backend/login/dto/LoginRequestDto.java
@@ -6,7 +6,7 @@ import lombok.Setter;
 
 @Getter
 @Setter
-public class LoginDto {
+public class LoginRequestDto {
     @Schema(description = "아이디")
     private String userName;
 

--- a/src/main/java/com/homefit/backend/login/service/AuthenticationService.java
+++ b/src/main/java/com/homefit/backend/login/service/AuthenticationService.java
@@ -1,12 +1,12 @@
 package com.homefit.backend.login.service;
 
-import com.homefit.backend.login.dto.LoginDto;
+import com.homefit.backend.login.dto.LoginRequestDto;
 import com.homefit.backend.login.config.provider.JwtTokenProvider;
+import com.homefit.backend.login.dto.LoginResponseDto;
 import com.homefit.backend.login.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -17,12 +17,14 @@ public class AuthenticationService {
     private final JwtTokenProvider jwtTokenProvider;
     private final UserService userService;
 
-    public String login(LoginDto loginDto) {
-        Authentication authentication = authenticationManager.authenticate(
-                new UsernamePasswordAuthenticationToken(loginDto.getUserName(), loginDto.getPassword())
+    public LoginResponseDto login(LoginRequestDto loginRequestDto) {
+        authenticationManager.authenticate(
+                new UsernamePasswordAuthenticationToken(loginRequestDto.getUserName(), loginRequestDto.getPassword())
         );
 
-        User user = userService.findByUserName(loginDto.getUserName());
-        return jwtTokenProvider.generateToken(user);
+        User user = userService.findByUserName(loginRequestDto.getUserName());
+        String token = jwtTokenProvider.generateToken(user);
+
+        return new LoginResponseDto(user.getId(), token);
     }
 }

--- a/src/test/java/com/homefit/backend/login/service/LoginServiceTest.java
+++ b/src/test/java/com/homefit/backend/login/service/LoginServiceTest.java
@@ -2,7 +2,8 @@ package com.homefit.backend.login.service;
 
 import com.homefit.backend.login.config.provider.JwtTokenProvider;
 import com.homefit.backend.login.dto.AdminDto;
-import com.homefit.backend.login.dto.LoginDto;
+import com.homefit.backend.login.dto.LoginRequestDto;
+import com.homefit.backend.login.dto.LoginResponseDto;
 import com.homefit.backend.login.dto.UserDto;
 import com.homefit.backend.login.entity.RoleType;
 import com.homefit.backend.login.entity.User;
@@ -95,25 +96,26 @@ public class LoginServiceTest {
     @Order(2)
     void login_Success() {
         // Arrange
-        LoginDto loginDto = new LoginDto();
-        loginDto.setUserName("testUser");
-        loginDto.setPassword("password");
+        LoginRequestDto loginRequestDto = new LoginRequestDto();
+        loginRequestDto.setUserName("testUser");
+        loginRequestDto.setPassword("password");
 
         Authentication authentication = mock(Authentication.class);
         when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
                 .thenReturn(authentication);
 
-        User user = new User("testUser", "encodedPassword", RoleType.USER);
+        User user = new User(1L, "testUser", "encodedPassword", RoleType.USER);
         when(userRepository.findByUserName(anyString())).thenReturn(Optional.of(user));
 
         when(jwtTokenProvider.generateToken(any(User.class))).thenReturn("jwtToken");
 
         // Act
-        String result = authenticationService.login(loginDto);
+        LoginResponseDto result = authenticationService.login(loginRequestDto);
 
         // Assert
         assertNotNull(result);
-        assertEquals("jwtToken", result);
+        assertEquals(1L, result.getUserId());
+        assertEquals("jwtToken", result.getJwtToken());
         verify(authenticationManager).authenticate(any(UsernamePasswordAuthenticationToken.class));
         verify(userRepository).findByUserName(eq("testUser"));
         verify(jwtTokenProvider).generateToken(user);


### PR DESCRIPTION
## ⭐Key Changes
> 핵심 변경 사항에 대해서 적어주세요.
1. 리턴값 추가 : 기존에는 JWT만을 리턴했으나, 추가로 로그인한 사용자의 userId도 추가했어요..
2. 테스트 코드 변경 : 기존의 로그인 테스트 메서드(`login_Success`)에서 로그인한 사용자의 userId가 일치하는지에 대한 테스트 코드도 추가했어요..

<br>

## 📌Issue
> 닫을 issue 번호 : resolved #50

<br>

## 🩼Branch
> 반영 branch feat-50 -> dev

<br>

## 👪To Reviewers
> Docker에 잘 말아주세요...!